### PR TITLE
🔥 Hotfix: Downgrade Python 3.14 → 3.13 for deploy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completely rewrote README.md for waifu bot architecture
 - Updated .env.example with new required variables
 - Deploy workflow reads version.txt and creates GitHub releases
-- Upgraded Python from 3.11-slim to 3.14-slim in Dockerfile
+- **Downgraded Python from 3.14-slim to 3.13-slim** (hotfix for pydantic-core build issue)
 - **Enhanced CONTRIBUTING.md with pre-commit workflow**
   - Automated quality checks before commits
   - Step-by-step setup instructions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Simplified single-stage build for reliability
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## 🔥 Critical Hotfix

### Issue
Deploy workflow **FAILED** after PR #4 merge:
- **Error**: `pydantic-core` failed to build on Python 3.14
- **Cause**: Python 3.14 too new, no pre-built wheels available
- **Impact**: All deployments blocked

**Failed run**: https://github.com/dcversus/dcmaidbot/actions/runs/18850924598

### Solution
Downgrade to Python 3.13-slim:
- ✅ Stable, production-ready
- ✅ All dependency wheels available
- ✅ Proven compatibility

### Changes
- `Dockerfile`: `python:3.14-slim` → `python:3.13-slim`
- `CHANGELOG.md`: Documented hotfix

### Testing Plan
After merge, verify:
1. ✅ Docker build succeeds
2. ✅ Deploy workflow completes
3. ✅ Image pushed to GHCR
4. ✅ Bot deploys to Kubernetes
5. ✅ Bot responds in production

### Merge Strategy
**Immediate merge recommended** - blocks all deployments

- [ ] CI passes
- [ ] Merge to main
- [ ] Watch deploy workflow
- [ ] Verify with kubectl
- [ ] Test production bot

---

Nya~ Fixing deploy ASAP! 🎀🔧