### PR TITLE
EMERGENCY: Fix missing bot_webhook.py in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated .env.example with new required variables
 - Deploy workflow reads version.txt and creates GitHub releases
 - **Downgraded Python from 3.14-slim to 3.13-slim** (hotfix for pydantic-core build issue)
+
+### Fixed
+- **CRITICAL: Added bot_webhook.py to Docker image** (emergency fix for production crash)
+  - Dockerfile CMD referenced bot_webhook.py but file was not copied
+  - Caused all pods to enter CrashLoopBackOff state
+  - Fixed by adding COPY bot_webhook.py to Dockerfile
 - **Enhanced CONTRIBUTING.md with pre-commit workflow**
   - Automated quality checks before commits
   - Step-by-step setup instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completely rewrote README.md for waifu bot architecture
 - Updated .env.example with new required variables
 - Deploy workflow reads version.txt and creates GitHub releases
-- Upgraded Python from 3.11-slim to 3.14-slim in Dockerfile
+- **Downgraded Python from 3.14-slim to 3.13-slim** (hotfix for pydantic-core build issue)
 - **Enhanced CONTRIBUTING.md with pre-commit workflow**
   - Automated quality checks before commits
   - Step-by-step setup instructions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Simplified single-stage build for reliability
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY bot.py .
+COPY bot_webhook.py .
 COPY handlers/ ./handlers/
 COPY middlewares/ ./middlewares/
 COPY models/ ./models/

--- a/PRPs/PRP-003.md
+++ b/PRPs/PRP-003.md
@@ -264,3 +264,58 @@ Migrate from JSON/Redis to PostgreSQL for persistent storage of users, messages,
 2. Deploy to production
 3. Run production validation checklist above
 4. Proceed to PRP-004 (Memories System)
+
+---
+
+### 2025-10-27 - Post-Deploy Findings: Image Pull Issue
+
+**Status**: ⚠️ CRITICAL DEPLOYMENT ISSUE FOUND
+
+**Problem**: Production pod is NOT running the latest Docker image
+- Expected: Python 3.13-slim (SHA: a0424f89e556...)
+- Actual: Python 3.11.14 (SHA: fdde98ac81..., 21+ hours old)
+
+**Root Cause**: Helm chart configuration issue
+- Chart uses `imagePullPolicy: IfNotPresent`
+- Chart uses `image.tag: "latest"` (mutable tag)
+- Kubernetes nodes cache `latest` tag with IfNotPresent policy
+- Manual kubectl patches get reverted by ArgoCD
+
+**Impact**:
+- ✅ Bot is running and healthy (2 admins loaded, polling active)
+- ❌ But NOT running the new Python 3.13 code from PR #7 hotfix
+- ❌ PR #4 changes (PostgreSQL, PRP-013, pre-commit) also not deployed
+
+**Fix Required in uz0/core-charts**:
+
+**Option 1 (RECOMMENDED)**: Use semantic versioning
+```yaml
+# charts/dcmaidbot/prod.tag.yaml
+image:
+  tag: "0.1.0"  # Match version.txt and GitHub releases
+  pullPolicy: IfNotPresent  # Works fine with versioned tags
+```
+
+**Option 2**: Force always pull
+```yaml
+# charts/dcmaidbot/values.yaml
+image:
+  tag: "latest"
+  pullPolicy: Always  # Always pull mutable tags
+```
+
+**Why Option 1 is better**:
+- Predictable deployments (know exactly what version is running)
+- Easy rollbacks (change tag back to 0.0.9)
+- Clear audit trail (version history)
+- Matches our release workflow (version.txt → GitHub Release → Docker tags)
+- Standard GitOps best practice
+
+**Verification Steps After Fix**:
+1. Update core-charts with version tag
+2. Wait for ArgoCD to sync
+3. Verify new pod: `kubectl exec <pod> -n prod-core -- python --version`
+4. Should show: Python 3.13.x
+5. Check logs for database connection (PostgreSQL from PR #4)
+
+**Next PR to Create**: uz0/core-charts PR to update dcmaidbot chart configuration


### PR DESCRIPTION
## 🚨 EMERGENCY FIX - PRODUCTION DOWN

**Status**: Both production pods in CrashLoopBackOff

**Root Cause**: Dockerfile references `bot_webhook.py` in CMD but doesn't copy it

**Error**:
```
python: can't open file '/app/bot_webhook.py': [Errno 2] No such file or directory
```

**Fix**: Add `COPY bot_webhook.py .` to Dockerfile line 19

**Impact**: All deployments since c57c2b0 (Python 3.13 hotfix) are broken

**Verification**: Build will include bot_webhook.py, pods will start successfully

## Changes
- Add bot_webhook.py to Docker COPY commands

## Next Steps
1. Merge immediately
2. Deploy workflow will rebuild with fixed Dockerfile
3. Production pods will recover