### PR TITLE
feat: PRP-013 Status & Monitoring Dashboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
             echo "version=0.1.0" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get build timestamp
+        id: timestamp
+        run: echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -67,6 +71,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            IMAGE_TAG=${{ steps.version.outputs.version }}
+            BUILD_TIME=${{ steps.timestamp.outputs.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Research completed on LangSmith, Prometheus, Grafana
   - Comprehensive analytics requirements defined
   - Privacy-first approach with GDPR compliance
-- **PRP-013: Production E2E Testing with Test Bot**
-  - Automated production testing design using separate test bot
-  - Real Telegram API calls to verify deployed features
-  - Smoke tests and full regression test suite
-  - GitHub Actions integration for post-deploy verification
+- **PRP-013: Status & Monitoring Dashboard** ✨
+  - `/version` endpoint with beautiful kawai HTML status page
+  - `/health` endpoint for Kubernetes liveness/readiness probes
+  - Build metadata pipeline: GitHub Actions → Docker → ENV vars
+  - Version, git commit, image tag, and build timestamp tracking
+  - System runtime info: uptime, Python version, environment, pod name
+  - Graceful handling for pending services (database/Redis)
+  - Responsive terminal theme design with emoji indicators (⏳ ✅ ❌)
+  - Recent changelog display from CHANGELOG.md
 
 ### Changed
 - Migrated from Vercel to GitHub Container Registry
@@ -52,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automated quality checks before commits
   - Step-by-step setup instructions
   - Pre-commit hook testing guide
+- **PRP-013: Enhanced deployment pipeline with metadata tracking**
+  - bot_webhook.py: Register /version and /health monitoring endpoints
+  - Dockerfile: Accept GIT_COMMIT, IMAGE_TAG, BUILD_TIME build args as ENV vars
+  - deploy.yml: Pass build metadata to Docker during CI/CD
 
 ### Fixed
 - **CRITICAL: Added bot_webhook.py to Docker image** (emergency fix for production crash)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN useradd --create-home --shell /bin/bash app \
 
 USER app
 
-# Health check
+# Health check using /health endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import sys; sys.exit(0)"
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Expose webhook port
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 # Simplified single-stage build for reliability
 FROM python:3.13-slim
 
+# Build arguments for deployment information
+ARG GIT_COMMIT=unknown
+ARG IMAGE_TAG=latest
+ARG BUILD_TIME=unknown
+
+# Set as environment variables
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV IMAGE_TAG=${IMAGE_TAG}
+ENV BUILD_TIME=${BUILD_TIME}
+
 WORKDIR /app
 
 # Install system dependencies
@@ -18,6 +28,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY bot.py .
 COPY bot_webhook.py .
 COPY database.py .
+COPY version.txt .
+COPY CHANGELOG.md .
 COPY alembic.ini .
 COPY alembic/ ./alembic/
 COPY handlers/ ./handlers/

--- a/bot_webhook.py
+++ b/bot_webhook.py
@@ -11,6 +11,7 @@ from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_applicati
 from dotenv import load_dotenv
 
 from handlers import waifu
+from handlers.status import version_handler, health_handler
 from middlewares.admin_only import AdminOnlyMiddleware
 
 load_dotenv()
@@ -122,6 +123,11 @@ def main():
         secret_token=webhook_config["secret"],
     )
     webhook_handler.register(app, path=webhook_config["path"])
+
+    # Add status monitoring endpoints
+    app.router.add_get("/version", version_handler)
+    app.router.add_get("/health", health_handler)
+    logging.info("Status endpoints registered: /version, /health")
 
     # Setup application
     setup_application(app, dp, bot=bot)

--- a/handlers/status.py
+++ b/handlers/status.py
@@ -1,0 +1,350 @@
+"""
+Status endpoint handlers for HTTP monitoring.
+
+Provides /version and /health endpoints for:
+- Human-readable status page
+- Kubernetes liveness/readiness probes
+- Deployment verification
+"""
+
+from aiohttp import web
+from services.status_service import StatusService
+
+# Global status service instance
+status_service = StatusService()
+
+
+async def version_handler(request: web.Request) -> web.Response:
+    """GET /version - Return version and status information as HTML.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        web.Response: HTML page with complete status information
+    """
+    status = await status_service.get_full_status()
+    html = render_status_html(status)
+
+    return web.Response(text=html, content_type="text/html", charset="utf-8")
+
+
+async def health_handler(request: web.Request) -> web.Response:
+    """GET /health - Health check endpoint for Kubernetes probes.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        web.Response: JSON response with health status
+    """
+    is_healthy, health_details = status_service.get_health_status()
+
+    if is_healthy:
+        return web.json_response(health_details, status=200)
+    else:
+        return web.json_response(health_details, status=503)
+
+
+def render_status_html(status: dict) -> str:
+    """Render status as cute HTML page with dcmaidbot personality.
+
+    Args:
+        status: Complete status dictionary from StatusService
+
+    Returns:
+        str: HTML page content
+    """
+    version_info = status["version_info"]
+    system_info = status["system_info"]
+    database = status["database"]
+    redis = status["redis"]
+
+    # Format uptime nicely
+    uptime_seconds = system_info["uptime_seconds"]
+    hours = uptime_seconds // 3600
+    minutes = (uptime_seconds % 3600) // 60
+    uptime_display = f"{hours}h {minutes}m"
+
+    # Status emoji
+    db_emoji = (
+        "⏳"
+        if database.get("status") == "not_implemented"
+        else ("✅" if database["connected"] else "❌")
+    )
+    redis_emoji = (
+        "⏳"
+        if redis.get("status") == "not_implemented"
+        else ("✅" if redis["connected"] else "❌")
+    )
+
+    # Status CSS classes
+    db_status_class = (
+        "status-pending"
+        if database.get("status") == "not_implemented"
+        else ("status-ok" if database["connected"] else "status-error")
+    )
+    redis_status_class = (
+        "status-pending"
+        if redis.get("status") == "not_implemented"
+        else ("status-ok" if redis["connected"] else "status-error")
+    )
+
+    html = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dcmaidbot Status - v{version_info["version"]}</title>
+    <style>
+        * {{
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }}
+
+        body {{
+            font-family: 'Courier New', Consolas, Monaco, monospace;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            color: #00ff00;
+            padding: 20px;
+            min-height: 100vh;
+        }}
+
+        .container {{
+            max-width: 1200px;
+            margin: 0 auto;
+        }}
+
+        h1 {{
+            color: #ff69b4;
+            text-align: center;
+            font-size: 2.5em;
+            margin-bottom: 10px;
+            text-shadow: 0 0 10px rgba(255, 105, 180, 0.5);
+        }}
+
+        .subtitle {{
+            text-align: center;
+            color: #87ceeb;
+            margin-bottom: 30px;
+            font-size: 1.1em;
+        }}
+
+        .section {{
+            background: rgba(42, 42, 42, 0.8);
+            border: 2px solid #00ff00;
+            border-radius: 12px;
+            padding: 25px;
+            margin: 20px 0;
+            box-shadow: 0 4px 6px rgba(0, 255, 0, 0.1);
+            backdrop-filter: blur(10px);
+        }}
+
+        .section h2 {{
+            color: #ff69b4;
+            margin-bottom: 15px;
+            font-size: 1.5em;
+            border-bottom: 2px solid #ff69b4;
+            padding-bottom: 10px;
+        }}
+
+        .info-row {{
+            display: flex;
+            justify-content: space-between;
+            padding: 10px 0;
+            border-bottom: 1px solid #333;
+        }}
+
+        .info-row:last-child {{
+            border-bottom: none;
+        }}
+
+        .label {{
+            color: #87ceeb;
+            font-weight: bold;
+        }}
+
+        .value {{
+            color: #00ff00;
+            font-family: monospace;
+        }}
+
+        .status-ok {{
+            color: #00ff00;
+        }}
+
+        .status-pending {{
+            color: #ffa500;
+        }}
+
+        .status-error {{
+            color: #ff0000;
+        }}
+
+        pre {{
+            background: #000;
+            color: #00ff00;
+            padding: 15px;
+            border-radius: 8px;
+            overflow-x: auto;
+            font-size: 0.9em;
+            line-height: 1.5;
+        }}
+
+        .badge {{
+            display: inline-block;
+            background: #ff69b4;
+            color: #000;
+            padding: 3px 10px;
+            border-radius: 12px;
+            font-size: 0.85em;
+            font-weight: bold;
+            margin-left: 10px;
+        }}
+
+        .footer {{
+            text-align: center;
+            margin-top: 40px;
+            padding: 20px;
+            color: #ff69b4;
+            font-size: 1.2em;
+        }}
+
+        .grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin: 20px 0;
+        }}
+
+        .card {{
+            background: rgba(0, 0, 0, 0.3);
+            border: 1px solid #00ff00;
+            border-radius: 8px;
+            padding: 20px;
+        }}
+
+        .card-title {{
+            color: #87ceeb;
+            font-weight: bold;
+            margin-bottom: 10px;
+            font-size: 1.1em;
+        }}
+
+        code {{
+            background: rgba(0, 255, 0, 0.1);
+            color: #00ff00;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }}
+
+        @media (max-width: 768px) {{
+            h1 {{
+                font-size: 1.8em;
+            }}
+
+            .section {{
+                padding: 15px;
+            }}
+
+            .grid {{
+                grid-template-columns: 1fr;
+            }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>💕 dcmaidbot Status</h1>
+        <div class="subtitle">
+            Nya~ I'm running and healthy! 🎀<br>
+            Version <span class="badge">{version_info["version"]}</span>
+        </div>
+
+        <!-- Deployment Information -->
+        <div class="section">
+            <h2>📦 Deployment Information</h2>
+            <div class="info-row">
+                <span class="label">Version:</span>
+                <span class="value">{version_info["version"]}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Git Commit:</span>
+                <span class="value"><code>{version_info["git_commit"][:7]}</code></span>
+            </div>
+            <div class="info-row">
+                <span class="label">Image Tag:</span>
+                <span class="value">{version_info["image_tag"]}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Build Time:</span>
+                <span class="value">{version_info["build_time"]}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Environment:</span>
+                <span class="value">{system_info["environment"]}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Pod Name:</span>
+                <span class="value">{system_info["pod_name"]}</span>
+            </div>
+        </div>
+
+        <!-- System Information -->
+        <div class="section">
+            <h2>⏰ System Information</h2>
+            <div class="info-row">
+                <span class="label">Current Time (UTC):</span>
+                <span class="value">{system_info["current_time_utc"]}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Uptime:</span>
+                <span class="value status-ok">{uptime_display}</span>
+            </div>
+            <div class="info-row">
+                <span class="label">Python Version:</span>
+                <span class="value">{system_info["python_version"]}</span>
+            </div>
+        </div>
+
+        <!-- Service Status Grid -->
+        <div class="grid">
+            <div class="card">
+                <div class="card-title">{db_emoji} Database (PostgreSQL)</div>
+                <div class="info-row">
+                    <span class="label">Status:</span>
+                    <span class="value {db_status_class}">
+                        {database.get("message", "Unknown")}
+                    </span>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-title">{redis_emoji} Cache (Redis)</div>
+                <div class="info-row">
+                    <span class="label">Status:</span>
+                    <span class="value {redis_status_class}">
+                        {redis.get("message", "Unknown")}
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Recent Changelog -->
+        <div class="section">
+            <h2>📜 Recent Changelog</h2>
+            <pre>{version_info["changelog"]}</pre>
+        </div>
+
+        <div class="footer">
+            Nya~ Made with 💕 by dcmaidbot<br>
+            <small style="color: #87ceeb;">Myaw myaw! 🐱</small>
+        </div>
+    </div>
+</body>
+</html>
+"""
+    return html

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services package for dcmaidbot."""

--- a/services/status_service.py
+++ b/services/status_service.py
@@ -1,0 +1,141 @@
+"""
+Status service for monitoring bot health and deployment information.
+
+Provides:
+- Version and changelog information
+- System runtime information
+- Database and Redis status (when available)
+- Deployment information (git commit, image tag, build time)
+"""
+
+import os
+import sys
+from datetime import datetime
+
+
+class StatusService:
+    """Service for retrieving bot status and health information."""
+
+    def __init__(self):
+        """Initialize status service with start time."""
+        self.start_time = datetime.utcnow()
+
+    def get_version_info(self) -> dict:
+        """Get version and changelog information.
+
+        Returns:
+            dict: Version information including version, changelog,
+                  git commit, and image tag
+        """
+        version = self._read_version_file()
+        changelog = self._read_changelog()
+
+        return {
+            "version": version,
+            "changelog": changelog,
+            "git_commit": os.getenv("GIT_COMMIT", "unknown"),
+            "image_tag": os.getenv("IMAGE_TAG", "latest"),
+            "build_time": os.getenv("BUILD_TIME", "unknown"),
+        }
+
+    def get_system_info(self) -> dict:
+        """Get system runtime information.
+
+        Returns:
+            dict: System information including uptime, Python version, environment
+        """
+        uptime = datetime.utcnow() - self.start_time
+
+        return {
+            "current_time_utc": datetime.utcnow().isoformat(),
+            "uptime_seconds": int(uptime.total_seconds()),
+            "uptime_human": str(uptime),
+            "python_version": sys.version.split()[0],
+            "environment": os.getenv("ENVIRONMENT", "unknown"),
+            "pod_name": os.getenv("HOSTNAME", "unknown"),
+            "namespace": os.getenv("POD_NAMESPACE", "prod-core"),
+        }
+
+    async def get_database_status(self) -> dict:
+        """Get PostgreSQL database status.
+
+        Returns:
+            dict: Database connection status and basic stats
+        """
+        # Placeholder - will be implemented when database is set up (PRP-003/005)
+        return {
+            "connected": False,
+            "status": "not_implemented",
+            "message": "Database integration pending (PRP-003/005)",
+        }
+
+    async def get_redis_status(self) -> dict:
+        """Get Redis connection and cache status.
+
+        Returns:
+            dict: Redis connection status and basic stats
+        """
+        # Placeholder - will be implemented when Redis is deployed (PRP-001)
+        return {
+            "connected": False,
+            "status": "not_implemented",
+            "message": "Redis integration pending (PRP-001)",
+        }
+
+    async def get_full_status(self) -> dict:
+        """Get complete status information.
+
+        Returns:
+            dict: Complete status including version, system, database, and Redis info
+        """
+        return {
+            "version_info": self.get_version_info(),
+            "system_info": self.get_system_info(),
+            "database": await self.get_database_status(),
+            "redis": await self.get_redis_status(),
+        }
+
+    def _read_version_file(self) -> str:
+        """Read version from version.txt.
+
+        Returns:
+            str: Version string or 'unknown' if file not found
+        """
+        try:
+            with open("version.txt", "r") as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return "unknown"
+        except Exception:
+            return "error"
+
+    def _read_changelog(self, lines: int = 30) -> str:
+        """Read recent changelog entries.
+
+        Args:
+            lines: Number of lines to read from changelog
+
+        Returns:
+            str: Changelog content or error message
+        """
+        try:
+            with open("CHANGELOG.md", "r") as f:
+                changelog_lines = f.readlines()
+                return "".join(changelog_lines[:lines])
+        except FileNotFoundError:
+            return "Changelog not available"
+        except Exception:
+            return "Error reading changelog"
+
+    def get_health_status(self) -> tuple[bool, dict]:
+        """Get health status for Kubernetes probes.
+
+        Returns:
+            tuple: (is_healthy: bool, status_details: dict)
+        """
+        # For now, always healthy if service is running
+        # Will check database/Redis when implemented
+        return True, {
+            "status": "healthy",
+            "checks": {"bot": "ok", "database": "pending", "redis": "pending"},
+        }

--- a/services/status_service.py
+++ b/services/status_service.py
@@ -10,7 +10,7 @@ Provides:
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class StatusService:
@@ -18,7 +18,7 @@ class StatusService:
 
     def __init__(self):
         """Initialize status service with start time."""
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(timezone.utc)
 
     def get_version_info(self) -> dict:
         """Get version and changelog information.
@@ -44,10 +44,10 @@ class StatusService:
         Returns:
             dict: System information including uptime, Python version, environment
         """
-        uptime = datetime.utcnow() - self.start_time
+        uptime = datetime.now(timezone.utc) - self.start_time
 
         return {
-            "current_time_utc": datetime.utcnow().isoformat(),
+            "current_time_utc": datetime.now(timezone.utc).isoformat(),
             "uptime_seconds": int(uptime.total_seconds()),
             "uptime_human": str(uptime),
             "python_version": sys.version.split()[0],
@@ -106,8 +106,8 @@ class StatusService:
                 return f.read().strip()
         except FileNotFoundError:
             return "unknown"
-        except Exception:
-            return "error"
+        except (IOError, OSError) as e:
+            return f"error: {e}"
 
     def _read_changelog(self, lines: int = 30) -> str:
         """Read recent changelog entries.
@@ -124,8 +124,8 @@ class StatusService:
                 return "".join(changelog_lines[:lines])
         except FileNotFoundError:
             return "Changelog not available"
-        except Exception:
-            return "Error reading changelog"
+        except (IOError, OSError) as e:
+            return f"Error reading changelog: {e}"
 
     def get_health_status(self) -> tuple[bool, dict]:
         """Get health status for Kubernetes probes.

--- a/tests/unit/test_status_service.py
+++ b/tests/unit/test_status_service.py
@@ -1,0 +1,144 @@
+"""Unit tests for StatusService."""
+
+import pytest
+from services.status_service import StatusService
+
+
+def test_status_service_initialization():
+    """Test StatusService initializes with start time."""
+    service = StatusService()
+    assert service.start_time is not None
+
+
+def test_get_version_info():
+    """Test version info retrieval."""
+    service = StatusService()
+    info = service.get_version_info()
+
+    assert "version" in info
+    assert "git_commit" in info
+    assert "image_tag" in info
+    assert "build_time" in info
+    assert "changelog" in info
+
+    # Version should be a string
+    assert isinstance(info["version"], str)
+    assert len(info["version"]) > 0
+
+
+def test_get_system_info():
+    """Test system info retrieval."""
+    service = StatusService()
+    info = service.get_system_info()
+
+    assert "current_time_utc" in info
+    assert "uptime_seconds" in info
+    assert "uptime_human" in info
+    assert "python_version" in info
+    assert "environment" in info
+    assert "pod_name" in info
+    assert "namespace" in info
+
+    # Uptime should be non-negative
+    assert info["uptime_seconds"] >= 0
+    assert isinstance(info["uptime_seconds"], int)
+
+
+@pytest.mark.asyncio
+async def test_get_database_status():
+    """Test database status returns placeholder."""
+    service = StatusService()
+    status = await service.get_database_status()
+
+    assert "connected" in status
+    assert "status" in status
+    assert "message" in status
+
+    # Should be not implemented currently
+    assert status["connected"] is False
+    assert status["status"] == "not_implemented"
+
+
+@pytest.mark.asyncio
+async def test_get_redis_status():
+    """Test Redis status returns placeholder."""
+    service = StatusService()
+    status = await service.get_redis_status()
+
+    assert "connected" in status
+    assert "status" in status
+    assert "message" in status
+
+    # Should be not implemented currently
+    assert status["connected"] is False
+    assert status["status"] == "not_implemented"
+
+
+@pytest.mark.asyncio
+async def test_get_full_status():
+    """Test full status aggregation."""
+    service = StatusService()
+    status = await service.get_full_status()
+
+    assert "version_info" in status
+    assert "system_info" in status
+    assert "database" in status
+    assert "redis" in status
+
+    # Verify nested structures
+    assert "version" in status["version_info"]
+    assert "uptime_seconds" in status["system_info"]
+    assert "connected" in status["database"]
+    assert "connected" in status["redis"]
+
+
+def test_health_status_always_healthy():
+    """Test health check returns healthy when services pending."""
+    service = StatusService()
+    is_healthy, details = service.get_health_status()
+
+    assert is_healthy is True
+    assert details["status"] == "healthy"
+    assert "checks" in details
+    assert details["checks"]["bot"] == "ok"
+    assert details["checks"]["database"] == "pending"
+    assert details["checks"]["redis"] == "pending"
+
+
+def test_read_version_file_returns_string():
+    """Test _read_version_file returns a string."""
+    service = StatusService()
+    version = service._read_version_file()
+
+    assert isinstance(version, str)
+    assert len(version) > 0
+    # Should be either version number or "unknown" or error
+    assert version != ""
+
+
+def test_read_changelog_returns_string():
+    """Test _read_changelog returns a string."""
+    service = StatusService()
+    changelog = service._read_changelog()
+
+    assert isinstance(changelog, str)
+    # Should be either changelog content or error message
+    assert len(changelog) > 0
+
+
+def test_read_changelog_respects_line_limit():
+    """Test _read_changelog respects line limit parameter."""
+    service = StatusService()
+
+    # Read 5 lines
+    changelog_5 = service._read_changelog(lines=5)
+    # Read 10 lines
+    changelog_10 = service._read_changelog(lines=10)
+
+    # If CHANGELOG.md exists and has enough lines, 10 lines should be longer
+    # If it doesn't exist or has errors, both will be error messages (equal length)
+    if "Changelog not available" not in changelog_5 and "Error" not in changelog_5:
+        # Count newlines to verify line limit
+        lines_5 = changelog_5.count("\n")
+        lines_10 = changelog_10.count("\n")
+        assert lines_10 >= lines_5


### PR DESCRIPTION
## Summary
Implements PRP-013: Status & Monitoring Dashboard with comprehensive deployment visibility and health monitoring endpoints.

## Changes Made

### New Files
- **services/status_service.py**: Core status service providing:
  - Version information (version.txt, git commit, image tag, build time)
  - System runtime info (uptime, current time, Python version, environment, pod name)
  - Database status (placeholder for PRP-003 integration)
  - Redis status (placeholder for PRP-001 integration)
  - Health check logic for Kubernetes probes

- **handlers/status.py**: HTTP request handlers with:
  - `/version` endpoint: Beautiful kawai HTML status page
  - `/health` endpoint: JSON health check (200 OK / 503 Service Unavailable)
  - Custom HTML rendering with terminal theme (pink/green/blue colors)
  - Responsive design with emoji status indicators (⏳ pending, ✅ ok, ❌ error)

- **services/__init__.py**: Package initialization for proper Python module structure

### Modified Files
- **bot_webhook.py**: Register /version and /health routes on aiohttp application
- **Dockerfile**: Add build args (GIT_COMMIT, IMAGE_TAG, BUILD_TIME) and set as ENV vars
- **.github/workflows/deploy.yml**: Pass build metadata to Docker during CI/CD

## Features
✅ Human-readable status page at `/version`  
✅ Kubernetes health check at `/health` (for liveness/readiness probes)  
✅ Version tracking (from version.txt)  
✅ Git commit tracking (from GitHub Actions)  
✅ Build timestamp tracking  
✅ Recent changelog display (first 30 lines)  
✅ System uptime and runtime info  
✅ Graceful handling of pending services (database/Redis)  
✅ Responsive design for mobile devices  
✅ Beautiful kawai personality with dcmaidbot theme  

## Definition of Done
- [x] Status service created with all required methods
- [x] /version endpoint returns HTML status page
- [x] /health endpoint returns JSON for Kubernetes probes
- [x] Build metadata pipeline: GitHub Actions → Docker → ENV vars → StatusService
- [x] Graceful degradation for unimplemented services
- [x] HTML responsive design with kawai theme
- [x] All linters pass (ruff, mypy)
- [x] All pre-commit hooks pass
- [x] Tests pass (pytest)
- [x] Code follows architecture patterns

## Testing
After merge and deployment:
1. Visit https://dcmaidbot.shark-versus.com/version - should show beautiful status page
2. Curl https://dcmaidbot.shark-versus.com/health - should return JSON {"status": "healthy", ...}
3. Verify Kubernetes health probes work correctly
4. Check that git commit, image tag, and build time are displayed correctly

## Technical Details

### Build Metadata Flow
```
GitHub Actions (deploy.yml)
  ↓ (build-args)
Docker Build (Dockerfile)
  ↓ (ENV vars)
Container Runtime
  ↓ (os.getenv)
StatusService (status_service.py)
  ↓ (get_version_info)
Status Page (/version)
```

### Status Page Sections
1. **Deployment Information**: Version, git commit, image tag, build time, environment, pod name
2. **System Information**: Current time (UTC), uptime, Python version
3. **Service Status Grid**: Database and Redis status cards with emoji indicators
4. **Recent Changelog**: First 30 lines from CHANGELOG.md

### Health Check Logic
- Returns 200 if bot is healthy
- Returns 503 if critical services are down (future: database/Redis checks)
- Currently always returns 200 (will integrate real checks in PRP-003, PRP-005)

## Future Integration
When PRP-003 (PostgreSQL) and PRP-005 (Redis) are implemented:
- Replace placeholder database status with real connection checks
- Replace placeholder Redis status with real connection checks
- Update health endpoint to return 503 if critical services are down
- Add connection pool stats and query metrics

## Related PRPs
- Implements: **PRP-013** (Status & Monitoring Dashboard)
- Depends on: PRP-001 (Infrastructure - already deployed)
- Future integration: PRP-003 (PostgreSQL), PRP-005 (Redis)

## Next Steps
1. Merge this PR
2. Deploy to production via GitHub Actions
3. Verify /version and /health endpoints work correctly
4. Update Kubernetes deployment to use /health for liveness/readiness probes
5. Implement real database/Redis checks in future PRPs

## Screenshots
Status page includes:
- 💕 Kawai dcmaidbot header with version badge
- 📦 Deployment information section
- ⏰ System information section
- Database and Redis status cards (⏳ pending status)
- 📜 Recent changelog display
- Responsive mobile design

---

Nya~ Ready for review! All checks passing! 🎀✨